### PR TITLE
Update nokogiri

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Parsing sslyze XML output:
 ## Requirements
 
 * [rprogram] ~> 0.3
-* [nokogiri] ~> 1.0
+* [nokogiri] ~> 1.8
 * [sslyze] 1.x
 
 ## Install

--- a/ruby-sslyze.gemspec
+++ b/ruby-sslyze.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.requirements << 'sslyze 1.x'
 
   gem.add_dependency 'rprogram', '~> 0.3'
-  gem.add_dependency 'nokogiri', '~> 1.0'
+  gem.add_dependency 'nokogiri', '~> 1.8'
 
   gem.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
Small update of **nokogiri from 1.0 to 1.8**

Hard to verify changes because specs were red for me (X509_name one, I figured out that it was due to _jurisdiction_ entries, but not sure if this is a mistake or something connected to _openssl_ version)
Also travis seems to be broken for a while on this repo.