### PR TITLE
Require yard 0.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
 
   gem 'rspec', '~> 3.0'
 
-  gem 'yard', '~> 0.8'
+  gem 'yard', '~> 0.9'
   gem 'kramdown'
 end
 


### PR DESCRIPTION
Minor change (if someone was using `ruby-sslyze` with yard 0.8 they would have to update)